### PR TITLE
set-in-stone-branch/fixes merge pull request

### DIFF
--- a/KFTurbo/Classes/V_Berserker.uc
+++ b/KFTurbo/Classes/V_Berserker.uc
@@ -207,5 +207,5 @@ defaultproperties
     PerkIndex=4
 	CustomLevelInfo=""
     Requirements(0)="Deal %x damage with melee weapons."
-	SRLevelEffects(6)="100% extra melee damage|15% faster melee attacks|20% faster melee movement|20% less damage from Siren scream|60% less damage from Bloat bile|10% resistance to all damage|70% discount on melee weapons|20% increase in grenade capacity|Grenades put zeds into Stasis, increasing the damage they take|Spawn with a Machete|Can't be grabbed by Clots|Up to 4 zed-time extensions"
+	SRLevelEffects(6)="100% extra melee damage|15% faster melee attacks|25% faster melee movement|40% less damage from Siren scream|70% less damage from Bloat bile|15% resistance to all damage|70% discount on melee weapons|20% increase in grenade capacity|Grenades put zeds into Stasis, increasing the damage they take|Spawn with a Machete|Can't be grabbed by Clots|Up to 4 zed-time extensions"
 }

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -130,18 +130,18 @@ static function float GetMagCapacityMod(KFPlayerReplicationInfo KFPRI, KFWeapon 
 
 	if (Bullpup(Other) != None 
 		|| AK47AssaultRifle(Other) != None 
-		|| SCARMK17AssaultRifle(Other) != None
+		|| ThompsonSMG(Other) != None
 		|| MKb42AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
 	}
 	else if (ThompsonDrumSMG(Other) != None || SPThompsonSMG(Other) != none)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
 	}
-	else if (ThompsonSMG(Other) != None)
+	else if (SCARMK17AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
 	}
 	else if (M4AssaultRifle(Other) != None)
 	{
@@ -322,5 +322,5 @@ defaultproperties
     PerkIndex=3
 	CustomLevelInfo=""
 	Requirements(0)="Deal %x damage with Assault Rifles."
-	SRLevelEffects(6)="50% more damage with assault/battle rifles|40% less recoil with assault/battle rifles and SMGs|25% - 60% larger magazines for assault/battle rifles|25% more maximum ammo for assault/battle rifles|35% faster reload with all weapons|70% discount on assault/battle rifles|Spawn with an AK47|Can see cloaked Stalkers from 32m|Can see enemy health from 16m|Up to 4 zed-time extensions"
+	SRLevelEffects(6)="50% more damage with assault/battle rifles|40% less recoil with assault/battle rifles and SMGs|20% - 60% larger magazines for assault/battle rifles|25% more maximum ammo for assault/battle rifles|35% faster reload with all weapons|70% discount on assault/battle rifles|Spawn with an Bullpup|Can see cloaked Stalkers from 32m|Can see enemy health from 16m|Up to 4 zed-time extensions"
 }

--- a/KFTurbo/Classes/V_FieldMedic.uc
+++ b/KFTurbo/Classes/V_FieldMedic.uc
@@ -240,5 +240,5 @@ defaultproperties
 	PerkIndex=0
 	CustomLevelInfo=""
 	Requirements(0)="Heal %x HP on your teammates."
-	SRLevelEffects(6)="200% faster syringe recharge|75% more potent healing|75% less damage from Bloat bile|20% faster movement speed|100% larger medic gun clips|75% better body armor|70% discount on body armor|87% discount on medic guns|Grenades heal teammates and hurt enemies|Spawn with full armor and MP7M"
+	SRLevelEffects(6)="200% faster syringe recharge|75% more potent healing|75% less damage from Bloat bile|20% faster movement speed|100% larger medic gun clips|75% better body armor|70% discount on body armor|50% discount on medic guns|Grenades heal teammates and hurt enemies|Spawn with full armor and MP7M"
 }

--- a/KFTurbo/Classes/V_Firebug.uc
+++ b/KFTurbo/Classes/V_Firebug.uc
@@ -219,5 +219,5 @@ defaultproperties
 	PerkIndex=5
 	CustomLevelInfo=""
 	Requirements(0)="Deal %x damage with weapons that cause Burning."
-	SRLevelEffects(6)="60% extra damage with Flamethrower and Husk Gun|15% extra damage with MAC10, Trenchgun and Thompson Incendiary|60% faster reload speed with perk weapons|60% larger magazine for Flamethrower, MAC-10 and Thompson Incendiary|60% more ammo for with perk weapons|100% resistance to fire|100% extra Flamethrower range|Grenades set enemies on fire|70% discount on perk weapons|Spawn with a MAC-10"
+	SRLevelEffects(6)="60% extra damage with Flamethrower and Husk Gun|15% extra damage with MAC10, Trenchgun and Thompson Incendiary|60% faster reload speed with perk weapons|60% larger magazine for MAC-10 and Thompson Incendiary|60% more ammo for MAC-10 and Thompson Incendiary|20% more ammo and tank capacity for Flamethrower|100% extra Flamethrower range|Grenades set enemies on fire|70% discount on perk weapons|100% resistance to fire|Spawn with a MAC-10"
 }

--- a/KFTurbo/Classes/V_Sharpshooter.uc
+++ b/KFTurbo/Classes/V_Sharpshooter.uc
@@ -151,16 +151,13 @@ static function float GetReloadSpeedModifier(KFPlayerReplicationInfo KFPRI, KFWe
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.15f);
 	}
-	else if(Magnum44Pistol(Other) != None || Dual44Magnum(Other) != None)
-	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.4f);
-	}
 	else if (Winchester(Other) != None
 		|| Single(Other) != None || Dualies(Other) != None
 		|| Deagle(Other) != None || DualDeagle(Other) != None
 		|| MK23Pistol(Other) != None || DualMK23Pistol(Other) != None
 		|| M14EBRBattleRifle(Other) != None
-		|| SPSniperRifle(Other) != None)
+		|| SPSniperRifle(Other) != None || Magnum44Pistol(Other) != None 
+		|| Dual44Magnum(Other) != None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
 	}

--- a/KFTurbo/Classes/W_MP5M_Fire.uc
+++ b/KFTurbo/Classes/W_MP5M_Fire.uc
@@ -16,8 +16,8 @@ defaultproperties
      AmmoClass=Class'KFTurbo.W_MP5M_Ammo'
      FireAimedAnim="Fire_Iron"
      RecoilRate=0.060000
-     maxVerticalRecoilAngle=124
-     maxHorizontalRecoilAngle=75
+     maxVerticalRecoilAngle=100
+     maxHorizontalRecoilAngle=60
      RecoilVelocityScale=0.000000
      ShellEjectClass=Class'ROEffects.KFShellEjectMP5SMG'
      ShellEjectBoneName="Shell_eject"
@@ -26,8 +26,8 @@ defaultproperties
      bRandomPitchFireSound=False
      FireSoundRef="KF_MP5Snd.Fire.MP5_Fire_M"
      StereoFireSoundRef="KF_MP5Snd.Fire.MP5_Fire_S"
-     DamageMin=25
-     DamageMax=35
+     DamageMin=35
+     DamageMax=40
      Momentum=5500.000000
      FireRate=0.080000
      ShakeRotMag=(X=25.000000,Y=25.000000,Z=125.000000)
@@ -44,6 +44,7 @@ defaultproperties
      AmmoPerFire=1
      BotRefireRate=0.100000
      FlashEmitterClass=Class'ROEffects.MuzzleFlash1stMP'
-     Spread=0.01000
+     MaxSpread=0.060000
+     Spread=0.00500
      SpreadStyle=SS_Random
 }

--- a/KFTurboCardGame/Classes/P_Bloat_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Bloat_Weak.uc
@@ -64,5 +64,5 @@ defaultproperties
      OnlineHeadshotOffset=(X=5.000000,Z=40.000000)
 	 OnlineHeadshotScale=1.400000
      MeleeDamage=7
-	 MenuName="Diet Bloat"
+	 MenuName="Weak Bloat"
 }

--- a/KFTurboCardGame/Classes/P_Bloat_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Bloat_Weak.uc
@@ -60,8 +60,9 @@ defaultproperties
      MeleeRange=23.000000
      HealthMax=265.000000
      Health=265
-     HeadScale=1.300000
-     HeadRadius=6.000000
      HeadHealth=25.000000
+     OnlineHeadshotOffset=(X=5.000000,Z=40.000000)
+	 OnlineHeadshotScale=1.400000
      MeleeDamage=7
+	 MenuName="Diet Bloat"
 }

--- a/KFTurboCardGame/Classes/P_Clot_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Clot_Weak.uc
@@ -23,5 +23,5 @@ defaultproperties
      OnlineHeadshotOffset=(X=20.000000,Z=28.000000)
      OnlineHeadshotScale=1.000000
      MeleeDamage=3
-     MenuName="Clotlet"
+     MenuName="Weak Clot"
 }

--- a/KFTurboCardGame/Classes/P_Clot_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Clot_Weak.uc
@@ -9,9 +9,7 @@ simulated function PostBeginPlay()
 }
 defaultproperties
 {
-     HeadRadius=5.500000
      HeadHeight=1.320000
-     HeadScale=0.900000
      ColRadius=16.000000
      ColHeight=3.300000
      ColOffset=(Z=30.000000)
@@ -22,5 +20,8 @@ defaultproperties
      HealthMax=65.000000
      Health=65.000000
      HeadHealth=25.000000
+     OnlineHeadshotOffset=(X=20.000000,Z=28.000000)
+     OnlineHeadshotScale=1.000000
      MeleeDamage=3
+     MenuName="Clotlet"
 }

--- a/KFTurboCardGame/Classes/P_Crawler_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Crawler_Weak.uc
@@ -18,5 +18,5 @@ defaultproperties
      CollisionHeight=16.000000
      MeleeDamage=3
      OnlineHeadshotOffset=(X=20.000000,Z=5.000000)
-     MenuName="Baby Crawler"
+     MenuName="Weak Crawler"
 }

--- a/KFTurboCardGame/Classes/P_Crawler_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Crawler_Weak.uc
@@ -13,10 +13,10 @@ defaultproperties
      Health=35
      HeadHealth=25.000000
      HeadHeight=2.500000
-     HeadScale=1.000000
-     HeadRadius=5.500000
      PrePivot=(Z=-2.000000)
      CollisionRadius=16.000000
      CollisionHeight=16.000000
      MeleeDamage=3
+     OnlineHeadshotOffset=(X=20.000000,Z=5.000000)
+     MenuName="Baby Crawler"
 }

--- a/KFTurboCardGame/Classes/P_Fleshpound_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Fleshpound_Weak.uc
@@ -19,8 +19,9 @@ defaultproperties
      HealthMax=750.000000
      Health=750
      HeadHeight=2.200000
-     HeadScale=1.100000
-     HeadRadius=5.500000
      PrePivot=(Z=-16.000000)
      MeleeDamage=17
+     OnlineHeadshotOffset=(X=22.000000,Z=38.000000)
+     OnlineHeadshotScale=1.250000
+     MenuName="Mini Fleshpound"
 }

--- a/KFTurboCardGame/Classes/P_Fleshpound_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Fleshpound_Weak.uc
@@ -23,5 +23,5 @@ defaultproperties
      MeleeDamage=17
      OnlineHeadshotOffset=(X=22.000000,Z=38.000000)
      OnlineHeadshotScale=1.250000
-     MenuName="Mini Fleshpound"
+     MenuName="Weak Fleshpound"
 }

--- a/KFTurboCardGame/Classes/P_Gorefast_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Gorefast_Weak.uc
@@ -9,9 +9,7 @@ simulated function PostBeginPlay()
 }
 defaultproperties
 {
-     HeadRadius=5.500000
-     HeadHeight=1.650000
-     HeadScale=0.900000
+     HeadHeight=1.000000
      ColRadius=16.000000
      ColHeight=6.600000
      ColOffset=(Z=40.000000)
@@ -23,4 +21,7 @@ defaultproperties
      Health=125.000000
      HeadHealth=25.000000
      MeleeDamage=7
+     OnlineHeadshotOffset=(Y=5.000000,X=12.000000,Z=25.000000)
+     OnlineHeadshotScale=1.000000
+     MenuName="Gorefast Jr."
 }

--- a/KFTurboCardGame/Classes/P_Gorefast_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Gorefast_Weak.uc
@@ -23,5 +23,5 @@ defaultproperties
      MeleeDamage=7
      OnlineHeadshotOffset=(Y=5.000000,X=12.000000,Z=25.000000)
      OnlineHeadshotScale=1.000000
-     MenuName="Gorefast Jr."
+     MenuName="Weak Gorefast"
 }

--- a/KFTurboCardGame/Classes/P_Husk_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Husk_Weak.uc
@@ -71,8 +71,8 @@ defaultproperties
      MeleeRange=23.000000
      HealthMax=300.000000
      Health=300
-     HeadScale=1.300000
-     HeadRadius=5.500000
      MeleeDamage=7
      HuskFireProjClass=Class'KFTurboCardGame.P_Husk_Weak_Proj'
+     OnlineHeadshotOffset=(X=18.000000,Z=40.000000)
+     MenuName="Husk Lite"
 }

--- a/KFTurboCardGame/Classes/P_Husk_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Husk_Weak.uc
@@ -74,5 +74,5 @@ defaultproperties
      MeleeDamage=7
      HuskFireProjClass=Class'KFTurboCardGame.P_Husk_Weak_Proj'
      OnlineHeadshotOffset=(X=18.000000,Z=40.000000)
-     MenuName="Husk Lite"
+     MenuName="Weak Husk"
 }

--- a/KFTurboCardGame/Classes/P_Scrake_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Scrake_Weak.uc
@@ -23,5 +23,5 @@ defaultproperties
      MeleeDamage=10
      OnlineHeadshotOffset=(X=24.000000,Y=5.000000,Z=30.000000)
      OnlineHeadshotScale=1.250000
-     MenuName="Small Scrake"
+     MenuName="Weak Scrake"
 }

--- a/KFTurboCardGame/Classes/P_Scrake_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Scrake_Weak.uc
@@ -11,16 +11,17 @@ defaultproperties
 {
      ColOffset=(Z=35.000000)
      ColRadius=22.000000
-     ColHeight=10.000000
+     ColHeight=5.000000
      HeadHealth=325.000000
      MeleeRange=34.000000
      HealthMax=500.000000
      Health=500
      HeadHeight=2.050000
-     HeadScale=1.300000
-     HeadRadius=5.500000
      PrePivot=(Z=-13.000000)
      CollisionRadius=22.000000  
-     CollisionHeight=40.000000
+     CollisionHeight=35.000000
      MeleeDamage=10
+     OnlineHeadshotOffset=(X=24.000000,Y=5.000000,Z=30.000000)
+     OnlineHeadshotScale=1.250000
+     MenuName="Small Scrake"
 }

--- a/KFTurboCardGame/Classes/P_Siren_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Siren_Weak.uc
@@ -9,8 +9,6 @@ simulated function PostBeginPlay()
 
 defaultproperties
 {
-     HeadRadius=5.500000
-     HeadScale=0.9000000
      ScreamRadius=500
      ScreamForce=-100000
      ColRadius=16.000000
@@ -25,4 +23,6 @@ defaultproperties
      Health=150
      MeleeDamage=6
      ScreamDamage=4
+     OnlineHeadshotOffset=(X=8.000000,Z=30.000000)
+     MenuName="Squeaker"
 }

--- a/KFTurboCardGame/Classes/P_Siren_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Siren_Weak.uc
@@ -24,5 +24,5 @@ defaultproperties
      MeleeDamage=6
      ScreamDamage=4
      OnlineHeadshotOffset=(X=8.000000,Z=30.000000)
-     MenuName="Squeaker"
+     MenuName="Weak Siren"
 }

--- a/KFTurboCardGame/Classes/P_Stalker_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Stalker_Weak.uc
@@ -21,5 +21,5 @@ defaultproperties
      MeleeDamage=5
      OnlineHeadshotOffset=(X=16.000000,Z=27.000000)
      OnlineHeadshotScale=1.100000
-     MenuName="Shortstack Stalker"
+     MenuName="Weak Stalker"
 }

--- a/KFTurboCardGame/Classes/P_Stalker_Weak.uc
+++ b/KFTurboCardGame/Classes/P_Stalker_Weak.uc
@@ -9,8 +9,6 @@ simulated function PostBeginPlay()
 }
 defaultproperties
 {
-     HeadRadius=5.500000
-     HeadScale=0.900000
      ColRadius=18.000000
      ColHeight=3.300000
      ColOffset=(Z=30.000000)
@@ -21,4 +19,7 @@ defaultproperties
      Health=50.000000
      HeadHealth=25.000000
      MeleeDamage=5
+     OnlineHeadshotOffset=(X=16.000000,Z=27.000000)
+     OnlineHeadshotScale=1.100000
+     MenuName="Shortstack Stalker"
 }

--- a/KFTurboCardGame/Classes/TurboCardDeck_Super.uc
+++ b/KFTurboCardGame/Classes/TurboCardDeck_Super.uc
@@ -669,7 +669,7 @@ defaultproperties
         OnActivateCard=ActivateTooMuchForZBlock
     End Object
     DeckCardObjectList(28)=TurboCard'TooMuchForZBlock'
-/*
+
     Begin Object Name=DeEvolution Class=TurboCard_Super
         CardName(0)="De-Evolution"
         CardDescriptionList(0)="All zeds have"
@@ -680,6 +680,5 @@ defaultproperties
         OnActivateCard=ActivateDeEvolution
         CardID="SUPER_DEEVOLUTION"
     End Object
-    DeckCardObjectList(22)=TurboCard'DeEvolution'
-*/
+    DeckCardObjectList(29)=TurboCard'DeEvolution'
 }

--- a/changelog.md
+++ b/changelog.md
@@ -501,7 +501,6 @@
 - Fixed inconsistent cloaking state on dedicated servers.
 ### Husk
 - No longer fires cannon after dying
-- Added a new special variant: Scorcher
 ### Siren
 - No longer deals damage after dying
 - Now able to destroy high-speed projectiles on dedicated servers.

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,12 @@
 - **New Scoreboard**: Easier to tell crucial information at a glance. Now includes healing done.
 - **Added a Ping system**: Players can now ping enemies or pickups (default: X) to create a little text for their teammates.
 - **Custom Achievements**: Players can complete brand new KFTurbo-related server-tracked achievements.
- 
+- **Custom Emotes and Sound-Emotes**: Type a \[semicolon\] to insert an Emote in chat. Press \[Tab\] to autocomplete. Some of them even have cool sound effects.
+- **End of Wave statistics**: See Kills, Damage, Healing and Accuracy stats at the end of each wave.
+- **Optimized weapon penetration**: Fixed penetrating weapons not using recoil and spread and fixed several bugs related to bad penetration calculation.
+- **Fixed Various Grenade-related Exploits**: Such as throwing 2 grenades at point blank and getting instant weapon switching by inputting a grenade throw command.
+- **Vote to skip trader time**: Players can type `endtrader` in console to skip trader time.
+
 
 - **TBA**: insert changes here🚧
 
@@ -18,7 +23,7 @@
     - No longer causes zed to panic (dancing animation)
     - No longer flinches zeds
     - Reduces movement speed based on the weapon it is inflicted with
-    - Reduces damage dealt by the afflicted zed by 20%
+    - Reduces damage dealt by the afflicted zed by 10%
 - **Stasis**
     - Reduces movement speed by 10%
     - Increases damage small zeds take by 100%
@@ -30,6 +35,7 @@
     - Causes zed to panic
     - Reduces movement speed by 50%
     - Reduces scrake movement speed by 75%
+    - Disables siren scream
 
 ## Perk Changes
 
@@ -37,7 +43,6 @@
 - Spawn with a Shotgun ⚠️
 
 - **Weapons**
-
     - **Shotgun**: 
         - Weight 8 -> 7 🟢
         - 20% faster reload speed 🟢
@@ -81,10 +86,12 @@
     - **Hunting Shotgun**:
         - Unchanged 🟦
 
-    - **VLAD-9000**: Reworked
+    - **VLAD-9000**: Reworked ⚠️
         - Fires a single nail that deals high damage and pierces multiple zeds 🆕
         - Alternate fire toggles a laser aim module 🆕
         - Has no spread and inaccuracy 🟢
+        - 25% faster fire rate 🟢
+        - 40% faster reload speed 🟢
         - Weight 8 -> 11 🔻
         - Great for stunning scrakes or taking out long range threats ⚠️
 
@@ -96,13 +103,14 @@
     - 1.8x bonus headshot multiplier for the VLAD 9000
     - 1.5x bonus headshot multiplier for off-perk weapons
 - Crossbow and M99 Ammo now gets a 30% purchase cost discount 🟢
-- 44 Magnum and Dual Magnum bonus reload speed 60% -> 40%. 🔻
 - M99 and Crossbow bonus reload speed 60% -> 15%. 🔻
 - Crossbow and M99 no longer get a purchase cost discount 🔻
 - 60% faster reload speed with perk weapons 🟦
 - Spawn with a Lever Action Rifle ⚠️
 
 - **Weapons**
+    - **Dual 9mm**
+        - Weight 3 -> 1 🟢
 
     - **MK23 & Dual MK23**
         - 9% faster reload speed 🟢
@@ -132,7 +140,7 @@
         - 60% tighter spread 🟢
 
         - 20% more recoil 🔻
-        - Magazine capacity 10 -> 6 🔻
+        - Magazine capacity 10 -> 7 🔻
         - 17% more expensive 🔻
         - Headshot bonus damage reduced by 13% 🔻
         - 20% less maximum ammo 🔻
@@ -155,8 +163,7 @@
 - Thompson Drum bonus magazine size 25% -> 60% 🟢
 - M4 203 bonus magazine size 25% -> 34% 🟢
 - FN FAL bonus magazine size 25% -> 67% 🟢
-- SCARMK17 bonus magazine size 25% -> 20% 🔻
-- Thompson SMG bonus magazine size 25% -> 20% 🔻
+- Bullpup, AK47, MKb42,Thompson SMG bonus magazine size 25% -> 20% 🔻
 - Spawn with a Bullpup ⚠️
 
 - **Weapons**
@@ -289,17 +296,17 @@
         - 43% more player pushback on firing 🔻
     - **Pipe Bomb**
         - Removed the exploit which let players detonate pipe bombs multiple times by shooting it ⚠️
-        - Moved to inventory group 5 ⚠️
+        - Players can opt into moving it to weapon category slot 5 via the Turbo menu ⚠️
 
     - **Seeker Six Rocket Launcher** 
-        - 250% increased explosive damage 🟢
-        - 100% increased impact damage 🟢
+        - 200% increased explosive damage 🟢
         - 24% cheaper base price 🟢
 
+        - 33% reduced impact damage 🔻
         - Weight 7 -> 8 🔻
         - 11% more expensive 🔻
         - 7% slower reload speed 🔻
-        - 63% less maximum ammo 🔻
+        - 45% less maximum ammo 🔻
 
 ### Field Medic
 - Healing grenades now have a new model and bounce more 🆕
@@ -324,9 +331,11 @@
         - 45% less maximum ammo 🔻
         - 19% lower fire rate 🔻
     - **MP5**
-        - 17% increased damage 🟢
+        - 13% increased damage 🟢
         - 12% faster reload speed 🟢
         - 56% cheaper base price. 🟢
+        - 50% tighter spread 🟢
+        - 20% less recoil 🟢
         - Firing type is no longer high RoF ⚠️
         
         - Magazine capacity 32 -> 30 🔻
@@ -369,13 +378,13 @@
 
 ### Berserker
 - Grenades are replaced with stun grenades that put zeds into [**Stasis**](#afflictions) 🆕
-- 20% siren scream damage reduction 🆕
+- 40% siren scream damage reduction 🆕
 - 20% increase to grenade capacity 🟢
 - Stun grenades cannot be disintegrated by siren screams 🟢
 - Melee movement speed bonus 30% -> 25% 🔻
-- Damage resistance 40% -> 10% 🔻
+- Damage resistance 40% -> 15% 🔻
 - Melee swing speed 25% -> 15% 🔻
-- Bloat bile damage reduction 80% -> 60% 🔻
+- Bloat bile damage reduction 80% -> 70% 🔻
 - Patriarch can never deal more than 95 damage to the Berserker ⚠️
 - Spawn with a Machete ⚠️
 
@@ -421,14 +430,19 @@
 ### Firebug
 - Fire grenades now have a new model and bounce more 🆕
 - Trenchgun, MAC-10 and Thompson SMG now receive a 15% damage bonus 🟢
-- Flamethrower, MAC-10 and Thompson SMG receive a 60% magazine capacity bonus 🟢
+- MAC-10 and Thompson SMG receive a 60% magazine capacity bonus 🟢
+- Flamethrower receives a 20% magazine capacity bonus 🔻
+- Bonus fuel capacity for the Flame Thrower 60% -> 20% 🔻
 - 60% faster reload speed for perk weapons 🟢
 - Fire DoT mechanics changed [**Burning**](#afflictions) ⚠️
 - Spawns with a MAC-10 and no armor ⚠️
 
 - **Weapons**
-    - **Flamethrower**
-        - 50% reduced direct damage 🔻
+    - **Flamethrower** Reworked ⚠️
+        - Now pierces up to 10 zeds 🆕
+        - Hitting a zed the first time causes a small explosion that deals AoE damage 🆕
+        - No longer detonates projectiles 🆕
+        - 33% reduced direct damage 🔻
         - 10% increased spread 🔻
         
     - **MAC10**
@@ -470,26 +484,28 @@
         - Chargeup time reduced by 33% 🟢
         - 100% tighter spread 🟢
         - 25% more maximum and starting ammo 🟢
+        - Projectile cannot be disintegrated by sirens 🟢
         
         - Weight 8 -> 11 🔻
 
 ## Zed changes
 
 ### Crawler
-- Added a new variant: Raptor
+- Added a new special variant: Raptor
 ### Gorefast
 - Added a new cosmetic variant: Classy Gorefast
-- Added a new variant: Assassin
+- Added a new special variant: Assassin
 ### Bloat
-- Added a new variant: Fathead
+- Added a new elite variant: Fathead
 ### Stalker
 - Fixed inconsistent cloaking state on dedicated servers.
 ### Husk
 - No longer fires cannon after dying
+- Added a new special variant: Scorcher
 ### Siren
 - No longer deals damage after dying
 - Now able to destroy high-speed projectiles on dedicated servers.
-- Added a new variant: Caroler
+- Added a new special variant: Caroler
 ### Scrake
 - Fixed "Slow Rage" state, where the scrake would be stuck with a slow movement speed in his charging animation
 - Now has a 25% damage resistance to Flare Revolver


### PR DESCRIPTION
- Medic: 
    - MP5
         - Fixed damage value being vanilla
         - Tightened spread
         - Lowered recoil
- Sharpshooter:
    - .44 magnum & Dual magnum
        - Increased sharpshooter reload speed bonus from 40% to 60%
- Commando:
    - Fixed bad magazine capacity (31, 46 etc..)

- Re-enabled De-evolution card
- Renamed the _weak zeds so they can be differentiated in the kill feed/ping system
- Fixed the online hitboxes for the _weak zeds.

https://github.com/user-attachments/assets/f4eda3dc-65f8-477c-bb00-49dde0170969

- Fixed bad information in Perk Selection menu
- Updated Changelog