### PR TITLE
Dakka branch merge pull request

### DIFF
--- a/KFTurbo/Classes/P_Fleshpound.uc
+++ b/KFTurbo/Classes/P_Fleshpound.uc
@@ -77,9 +77,23 @@ function TakeDamage( int Damage, Pawn InstigatedBy, Vector Hitlocation, Vector M
         }
 
         bIsHeadShot = IsHeadShot(Hitlocation, normal(Momentum), HeadShotCheckScale);
-
+        // Commando weapons don't get the damage reduction
+		if (
+            class<DamTypeBullpup>(DamageType) != None ||
+            class<DamTypeAK47AssaultRifle>(DamageType) != None ||
+            class<DamTypeSCARMK17AssaultRifle>(DamageType) != None ||
+            class<DamTypeM4AssaultRifle>(DamageType) != None ||
+            class<DamTypeMKb42AssaultRifle>(DamageType) != None ||
+            class<W_M4203_DT_Bullet>(DamageType) != None ||
+            class<W_FNFAL_DT>(DamageType) != None ||
+            class<W_ThompsonDrum_DT>(DamageType) != None ||
+            class<W_ThompsonSMG_DT>(DamageType) != None
+        )
+        {
+            // Do nothing
+        }
 		// Don't reduce the damage so much if its a high headshot damage weapon
-		if( (bIsHeadShot && WeaponDamageType.default.HeadShotDamageMult >= 1.5) || (class<DamTypeCrossbuzzsaw>(DamageType) != None))
+        else if( (bIsHeadShot && WeaponDamageType.default.HeadShotDamageMult >= 1.5) || (class<DamTypeCrossbuzzsaw>(DamageType) != None))
 		{
 			Damage *= 0.75;
 		}

--- a/KFTurbo/Classes/P_Fleshpound.uc
+++ b/KFTurbo/Classes/P_Fleshpound.uc
@@ -78,17 +78,7 @@ function TakeDamage( int Damage, Pawn InstigatedBy, Vector Hitlocation, Vector M
 
         bIsHeadShot = IsHeadShot(Hitlocation, normal(Momentum), HeadShotCheckScale);
         // Commando weapons don't get the damage reduction
-		if (
-            class<DamTypeBullpup>(DamageType) != None ||
-            class<DamTypeAK47AssaultRifle>(DamageType) != None ||
-            class<DamTypeSCARMK17AssaultRifle>(DamageType) != None ||
-            class<DamTypeM4AssaultRifle>(DamageType) != None ||
-            class<DamTypeMKb42AssaultRifle>(DamageType) != None ||
-            class<W_M4203_DT_Bullet>(DamageType) != None ||
-            class<W_FNFAL_DT>(DamageType) != None ||
-            class<W_ThompsonDrum_DT>(DamageType) != None ||
-            class<W_ThompsonSMG_DT>(DamageType) != None
-        )
+		if (class'V_Commando'.static.IsPerkDamageType(WeaponDamageType))
         {
             // Do nothing
         }

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -187,7 +187,7 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 
 	if (IsPerkAmmunition(AmmoType))
 	{
-		if (ThompsonDrumAmmo(AmmoType) != None)
+		if (AmmoType == class'W_ThompsonDrum_Ammo')
 			Multiplier *= LerpStat(KFPRI, 1.f, 1.4f);
 		else
 			Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -127,18 +127,17 @@ static function float GetMagCapacityMod(KFPlayerReplicationInfo KFPRI, KFWeapon 
 {
 	local float Multiplier;
 	Multiplier = 1.f;
-
-	if (Bullpup(Other) != None 
+	if (ThompsonDrumSMG(Other) != None || SPThompsonSMG(Other) != none)
+	{
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
+	}
+	else if (Bullpup(Other) != None 
 		|| AK47AssaultRifle(Other) != None 
 		|| ThompsonSMG(Other) != None
 		|| MKb42AssaultRifle(Other) != None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
-	}
-	else if (ThompsonDrumSMG(Other) != None || SPThompsonSMG(Other) != none)
-	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
-	}
+	} 
 	else if (SCARMK17AssaultRifle(Other) != None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
@@ -188,7 +187,10 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 
 	if (IsPerkAmmunition(AmmoType))
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
+		if (ThompsonDrumAmmo(AmmoType) != None)
+			Multiplier *= LerpStat(KFPRI, 1.f, 1.4f);
+		else
+			Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
 	}
 
 	ApplyAdjustedExtraAmmo(KFPRI, AmmoType, Multiplier);

--- a/KFTurbo/Classes/W_AK47_Fire.uc
+++ b/KFTurbo/Classes/W_AK47_Fire.uc
@@ -8,11 +8,13 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.75);
 }
 
 defaultproperties
 {
      AmmoClass=Class'KFTurbo.W_AK47_Ammo'
      MaxSpread=0.096000
+     DamageMin=45
+     DamageMax=51
 }

--- a/KFTurbo/Classes/W_Bullpup_Fire.uc
+++ b/KFTurbo/Classes/W_Bullpup_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.75);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 4, 0.9);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_Dual44_Fire.uc
+++ b/KFTurbo/Classes/W_Dual44_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.9);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 4, 0.9);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_FNFAL_Fire.uc
+++ b/KFTurbo/Classes/W_FNFAL_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 1, 0.9);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_FNFAL_Fire.uc
+++ b/KFTurbo/Classes/W_FNFAL_Fire.uc
@@ -16,6 +16,7 @@ defaultproperties
      DamageType=Class'KFTurbo.W_FNFAL_DT'
      DamageMin=52
      DamageMax=52
+     FireRate=0.150000
      bWaitForRelease=True
      AmmoClass=Class'KFTurbo.W_FNFAL_Ammo'
      MaxSpread=0.048000

--- a/KFTurbo/Classes/W_M4203_Fire_Bullet.uc
+++ b/KFTurbo/Classes/W_M4203_Fire_Bullet.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.5);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_MKb42_Fire.uc
+++ b/KFTurbo/Classes/W_MKb42_Fire.uc
@@ -8,11 +8,13 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.75);
 }
 
 defaultproperties
 {
      MaxSpread=0.102000
      AmmoClass=class'W_MKb42_Ammo'
+     DamageMin=45
+     DamageMax=51
 }

--- a/KFTurbo/Classes/W_Magnum44_Fire.uc
+++ b/KFTurbo/Classes/W_Magnum44_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.9);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 4, 0.9);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_SCARMK17_Fire.uc
+++ b/KFTurbo/Classes/W_SCARMK17_Fire.uc
@@ -8,11 +8,13 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 1, 0.75);
 }
 
 defaultproperties
 {
      MaxSpread=0.090000
      AmmoClass=class'W_SCARMK17_Ammo'
+     DamageMin=60
+     DamageMax=65
 }

--- a/KFTurbo/Classes/W_ThompsonDrum_Fire.uc
+++ b/KFTurbo/Classes/W_ThompsonDrum_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.75);
 }
 
 defaultproperties

--- a/KFTurbo/Classes/W_ThompsonSMG_Fire.uc
+++ b/KFTurbo/Classes/W_ThompsonSMG_Fire.uc
@@ -8,7 +8,7 @@ function DoFireEffect()
 
 function DoTrace(Vector Start, Rotator Direction)
 {
-	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 0, 0.0);
+	class'WeaponHelper'.static.PenetratingWeaponTrace(Start, Direction, KFWeapon(Weapon), self, 2, 0.5);
 }
 
 defaultproperties

--- a/changelog.md
+++ b/changelog.md
@@ -126,6 +126,7 @@
         - 14% increased damage 🟢
         - 10% tighter spread 🟢
         - Headshot bonus damage increased by 80% 🟢
+        - Penetration count 2 -> 4 🟢
 
         - Weight 2 -> 3 🔻
         - 20% more recoil 🔻
@@ -225,6 +226,7 @@
         - 60% tighter spread 🟢
 
         - Full-auto fire mode removed 🔻
+        - Maximum fire rate reduced by 75% 🔻
         - Magazine capacity 20 -> 12 🔻
         - 20% reduced damage 🔻
         - 36% less maximum and starting ammo 🔻

--- a/changelog.md
+++ b/changelog.md
@@ -168,7 +168,7 @@
 
 - **Weapons**
     - **Bullpup** 
-        - Now penetrates up to 2 zeds with a damage loss of 25% 🆕
+        - Now penetrates up to 4 zeds with a damage loss of 10% 🆕
         - Weight 6 -> 5 🟢
         - 8% increased damage 🟢
         - 90% tighter spread 🟢
@@ -178,6 +178,7 @@
         - 25% more expensive 🔻
         - 35% less maximum ammo 🔻
     - **Thompson Drum** 
+        - Now penetrates up to 2 zeds with a damage loss of 25% 🆕
         - 66% more maximum and starting ammo 🟢
         - 20% tighter spread 🟢
 
@@ -186,10 +187,14 @@
         - 54% more expensive 🔻
         - 23% reduced damage 🔻
     - **AK47** 
+        - Now penetrates up to 2 zeds with a damage loss of 25% 🆕
+        - 13% increased damage 🟢
         - Weight 6 -> 5 🟢
         - 20% tighter spread 🟢
 
     - **MKb42**
+        - Now penetrates up to 2 zeds with a damage loss of 25% 🆕
+        - 13% increased damage 🟢
         - 10% faster reload speed 🟢
         - 15% tighter spread 🟢
 
@@ -198,6 +203,7 @@
         - Uses the scope from the M4 ⚠️
         - Underbarrel grenade launcher is now loaded manually instead of automatically by pressing alt-fire again ⚠️
         - Firing type is no longer high RoF ⚠️
+        - Now penetrates up to 2 zeds with a damage loss of 50% 🆕
         - 36% cheaper than the M4 203 🟢
         - 25% less recoil 🟢
         - 23% increased damage 🟢
@@ -208,9 +214,11 @@
         - 17% less maximum grenades 🔻
         - 28% slower fire rate 🔻
     - **SCAR MK17**
+        - Now penetrates up to 1 zed with a damage loss of 25% 🆕
         - 25% tighter spread 🟢
 
     - **FN FAL** 
+        - Now penetrates up to 1 zed with a damage loss of 10% 🆕
         - 13% faster reload speed 🟢
         - 9% cheaper 🟢
         - Headshot bonus damage increased by 80% 🟢
@@ -223,9 +231,10 @@
     - **Thompson SMG**
         - New incendiary variant 🆕
         - Ignites enemies  [**Burning**](#afflictions) 🆕
+        - Firing type is no longer high RoF ⚠️
+        - Now penetrates up to 2 zeds with a damage loss of 50% 🆕
         - 12% less recoil 🟢
         - 15% tighter spread 🟢
-        - Firing type is no longer high RoF ⚠️
 
         - 63% slower fire rate 🔻
         - Magazine capacity 30 -> 25 🔻
@@ -259,6 +268,7 @@
         - Uses the scope from the M4 ⚠️
         - Underbarrel grenade launcher is now loaded manually instead of automatically by pressing alt-fire again ⚠️
         - Firing type is no longer high RoF ⚠️
+        - Now penetrates up to 2 zeds with a damage loss of 50% 🆕
         - 56% cheaper base price 🟢
         - 25% less recoil 🟢
         - 23% increased damage 🟢
@@ -468,9 +478,10 @@
     - **Thompson SMG**
         - New incendiary variant 🆕
         - Ignites enemies  [**Burning**](#afflictions) 🆕
+        - Firing type is no longer high RoF ⚠️
+        - Now penetrates up to 2 zeds with a damage loss of 50% 🆕
         - 12% less recoil 🟢
         - 15% tighter spread 🟢
-        - Firing type is no longer high RoF ⚠️
 
         - 63% slower fire rate 🔻
         - Magazine capacity 30 -> 25 🔻

--- a/changelog.md
+++ b/changelog.md
@@ -525,4 +525,5 @@
 - Fixed a bug that made the Fleshpound "friendly", preventing it from attacking
 - Fixed various issues with being on fire
 - Damage resistance to M99 reduced from 50% to 47.5%
+- Damage resistance to Commando weapons reduced from 50% to 0%
 - Takes 65% increased damage from Seeker Six instead of the normal 25% for explosives.


### PR DESCRIPTION
- Fixed bug which incorrectly assigned 25% mag size bonus for Thompson Drum instead of 60%
- Removed Fleshpound damage reduction for commando weapons
- Weapon changes
    - Bullpup: 2 penetrations @ 0.75x -> 4 penetrations @ 0.9x
    - Thompsondrum: 2 penetrations @ 0.75x | Perked reserve ammo 625 -> 700
    - AK47: Damage 45->51 |  2 penetrations @ 0.75x
        - No one would buy AK because SCAR is just that much better. This should make it decent enough to use until wave 7.
    - MKb42: Damage 45->51 |  2 penetrations @ 0.75x
        - Same issue as AK, except in this case the M4 203 is just a direct upgrade for like 30 dosh more.
    - M4203: 2 penetrations @ 0.5x
    - Thompson Inc SMG: 2 penetrations @ 0.5x
    - FAL: 1 penetration @ 0.9x | Capped firerate at 25% of the original FAL's full auto firerate.
    - SCAR: 1 penetration @ 0.75x
- .44 Magnum and Dual Magnums
    - Penetration count 2 -> 4

https://github.com/user-attachments/assets/6616da77-a355-4d6a-8d50-fc92b53f33bb

