### PR TITLE
Balance pass 26 3 merge PR

### DIFF
--- a/KFTurbo/Classes/P_Clot.uc
+++ b/KFTurbo/Classes/P_Clot.uc
@@ -22,7 +22,7 @@ function TakeDamage(int Damage, Pawn InstigatedBy, Vector HitLocation, Vector Mo
 		class'PawnHelper'.static.TakeDamage(Self, Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex, AfflictionData);
 	}
 
-    if ( (class<DamTypeBurned>(DamageType) != none) )
+    if (class<DamTypeBurned>(DamageType) != none) 
     {
         Damage *= 1.25f;
     }

--- a/KFTurbo/Classes/P_Clot.uc
+++ b/KFTurbo/Classes/P_Clot.uc
@@ -22,6 +22,11 @@ function TakeDamage(int Damage, Pawn InstigatedBy, Vector HitLocation, Vector Mo
 		class'PawnHelper'.static.TakeDamage(Self, Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex, AfflictionData);
 	}
 
+    if ( (class<DamTypeBurned>(DamageType) != none) )
+    {
+        Damage *= 1.25f;
+    }
+
 	Super.TakeDamage(Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex);
 
     if (Role == ROLE_Authority)

--- a/KFTurbo/Classes/P_Crawler.uc
+++ b/KFTurbo/Classes/P_Crawler.uc
@@ -24,6 +24,11 @@ function TakeDamage(int Damage, Pawn InstigatedBy, Vector HitLocation, Vector Mo
 		class'PawnHelper'.static.TakeDamage(Self, Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex, AfflictionData);
 	}
 
+    if ( (class<DamTypeBurned>(DamageType) != none) )
+    {
+        Damage *= 1.25f;
+    }
+
 	Super.TakeDamage(Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex);
 
     if (Role == ROLE_Authority)

--- a/KFTurbo/Classes/P_Crawler.uc
+++ b/KFTurbo/Classes/P_Crawler.uc
@@ -24,7 +24,7 @@ function TakeDamage(int Damage, Pawn InstigatedBy, Vector HitLocation, Vector Mo
 		class'PawnHelper'.static.TakeDamage(Self, Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex, AfflictionData);
 	}
 
-    if ( (class<DamTypeBurned>(DamageType) != none) )
+    if (class<DamTypeBurned>(DamageType) != none)
     {
         Damage *= 1.25f;
     }

--- a/KFTurbo/Classes/P_Scrake.uc
+++ b/KFTurbo/Classes/P_Scrake.uc
@@ -81,6 +81,11 @@ function TakeDamage(int Damage, Pawn InstigatedBy, Vector HitLocation, Vector Mo
 		Damage *= 0.5f;
 	}
 
+	if ( bIsHeadshot && (class<W_NailGun_DT>(DamageType) != none ) )
+	{
+		Damage *= 1.55f;
+	}
+
 	Super(KFMonster).TakeDamage(Damage, InstigatedBy, HitLocation, Momentum, DamageType, HitIndex);
 
 	if (!IsInState('SawingLoop') && !IsInState('RunningState') && ShouldRage())

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -132,28 +132,26 @@ static function float GetMagCapacityMod(KFPlayerReplicationInfo KFPRI, KFWeapon 
 {
 	local float Multiplier;
 	Multiplier = 1.f;
-	if (ThompsonDrumSMG(Other) != None || SPThompsonSMG(Other) != none)
+	if (ThompsonDrumSMG(Other) != None 
+		|| SPThompsonSMG(Other) != none 
+		|| W_FNFAL_Weap(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 2.0f);
 	}
 	else if (Bullpup(Other) != None
 		|| AK47AssaultRifle(Other) != None 
-		|| SCARMK17AssaultRifle(Other) != None
-		|| MKb42AssaultRifle(Other) != None)
+		|| MKb42AssaultRifle(Other) != None
+		|| M4AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.34f);
 	} 
 	else if (ThompsonSMG(Other) != None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
 	}
-	else if (M4AssaultRifle(Other) != None)
+	else if (SCARMK17AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.34f);
-	}
-	else if (W_FNFAL_Weap(Other) != None)
-	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 2.1f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.5f);
 	}
 
 	ApplyAdjustedMagCapacityModifier(KFPRI, Other, Multiplier);
@@ -190,11 +188,15 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 	local float Multiplier;
 	Multiplier = 1.f;
 
-	if (IsPerkAmmunition(AmmoType))
+	if (class<FragAmmo>(AmmoType) != None)
+	{
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
+	}
+	else if (IsPerkAmmunition(AmmoType))
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
 	}
-
+	
 	ApplyAdjustedExtraAmmo(KFPRI, AmmoType, Multiplier);
 
 	return Multiplier;
@@ -224,8 +226,7 @@ static function int AddDamage(KFPlayerReplicationInfo KFPRI, KFMonster Injured, 
 	case class'W_M4203_DT_Bullet' :
 	case class'W_FNFAL_DT' :
 	case class'W_ThompsonDrum_DT' :
-		return float(InDamage) * LerpStat(KFPRI, 1.05f, 1.5f);
-	case class'W_ThompsonSMG_DT' : //left this here for future balancing
+	case class'W_ThompsonSMG_DT' :
 		return float(InDamage) * LerpStat(KFPRI, 1.05f, 1.5f);
 	}
 
@@ -293,6 +294,7 @@ static function float GetCostScaling(KFPlayerReplicationInfo KFPRI, class<Pickup
 		Multiplier *= LerpStat(KFPRI, 0.9f, 0.3f);
 		break;
 	default:
+		Multiplier *= LerpStat(KFPRI, 0.9f, 0.9f);
 		break;
 	}
 

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -192,9 +192,16 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
 	}
-	else if (IsPerkAmmunition(AmmoType) && class<W_FNFAL_Ammo>(AmmoType) == None)
+	else if (IsPerkAmmunition(AmmoType))
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
+		if (class<W_FNFAL_Ammo>(AmmoType) != None)
+		{
+			Multiplier *= LerpStat(KFPRI, 1.f, 1.125f);
+		}
+		else
+		{
+			Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
+		}
 	}
 	
 	ApplyAdjustedExtraAmmo(KFPRI, AmmoType, Multiplier);
@@ -294,7 +301,10 @@ static function float GetCostScaling(KFPlayerReplicationInfo KFPRI, class<Pickup
 		Multiplier *= LerpStat(KFPRI, 0.9f, 0.3f);
 		break;
 	default:
-		Multiplier *= LerpStat(KFPRI, 0.9f, 0.9f);
+		if (class<KFWeaponPickup>(Item) != None)
+		{
+			Multiplier *= LerpStat(KFPRI, 0.9f, 0.9f);
+		}
 		break;
 	}
 

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -132,28 +132,29 @@ static function float GetMagCapacityMod(KFPlayerReplicationInfo KFPRI, KFWeapon 
 {
 	local float Multiplier;
 	Multiplier = 1.f;
-	if (ThompsonDrumSMG(Other) != None 
-		|| SPThompsonSMG(Other) != none 
-		|| W_FNFAL_Weap(Other) != None)
+	if (ThompsonDrumSMG(Other) != None || SPThompsonSMG(Other) != none)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 2.0f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
 	}
 	else if (Bullpup(Other) != None
 		|| AK47AssaultRifle(Other) != None 
-		|| MKb42AssaultRifle(Other) != None
-		|| M4AssaultRifle(Other) != None)
+		|| SCARMK17AssaultRifle(Other) != None
+		|| MKb42AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.34f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
 	} 
 	else if (ThompsonSMG(Other) != None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
 	}
-	else if (SCARMK17AssaultRifle(Other) != None)
+	else if (M4AssaultRifle(Other) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.5f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.34f);
 	}
-
+	else if (W_FNFAL_Weap(Other) != None)
+	{
+		Multiplier *= LerpStat(KFPRI, 1.f, 2.1f);
+	}
 	ApplyAdjustedMagCapacityModifier(KFPRI, Other, Multiplier);
 
 	return Multiplier;
@@ -190,7 +191,7 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 
 	if (class<FragAmmo>(AmmoType) != None)
 	{
-		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
+		Multiplier *= LerpStat(KFPRI, 1.f, 1.6f);
 	}
 	else if (IsPerkAmmunition(AmmoType))
 	{

--- a/KFTurbo/Classes/V_Commando.uc
+++ b/KFTurbo/Classes/V_Commando.uc
@@ -192,7 +192,7 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, class<Ammun
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.2f);
 	}
-	else if (IsPerkAmmunition(AmmoType))
+	else if (IsPerkAmmunition(AmmoType) && class<W_FNFAL_Ammo>(AmmoType) == None)
 	{
 		Multiplier *= LerpStat(KFPRI, 1.f, 1.25f);
 	}

--- a/KFTurbo/Classes/V_Sharpshooter.uc
+++ b/KFTurbo/Classes/V_Sharpshooter.uc
@@ -96,9 +96,6 @@ static function float GetHeadShotDamMulti(KFPlayerReplicationInfo KFPRI, KFPawn 
 	case class'W_SPSniper_DT' :
 		Multiplier = LerpStat(KFPRI, 1.05f, 1.6f);
 		break;
-	case class'W_NailGun_DT' :	
-		Multiplier = LerpStat(KFPRI, 1.05f, 1.2f);
-		break;
 	case class'W_Magnum44_DT' :
 	case class'W_Dual44_DT' :
 		return LerpStat(KFPRI, 1.05f, 1.45f);

--- a/KFTurbo/Classes/V_SupportSpec.uc
+++ b/KFTurbo/Classes/V_SupportSpec.uc
@@ -165,12 +165,14 @@ static function float GetCostScaling(KFPlayerReplicationInfo KFPRI, class<Pickup
 	case class'W_Boomstick_Pickup' :
 	case class'W_KSG_Pickup' :
 	case class'W_Shotgun_Pickup' :
-	case class'W_NailGun_Pickup' :
 	case class'W_SPShotgun_Pickup' :
 		Multiplier *= LerpStat(KFPRI, 0.9f, 0.3f);
 		break;
 	}
-
+	case class'W_NailGun_Pickup' :
+		Multiplier *= LerpStat(KFPRI, 0.9f, 0.5f);
+		break;
+		
 	ApplyCostScalingModifier(KFPRI, Item, Multiplier);
 	return Multiplier;
 }

--- a/KFTurbo/Classes/V_SupportSpec.uc
+++ b/KFTurbo/Classes/V_SupportSpec.uc
@@ -113,7 +113,7 @@ static function float AddExtraAmmoFor(KFPlayerReplicationInfo KFPRI, Class<Ammun
 		Multiplier = LerpStat(KFPRI, 1.f, 1.2f);
 		break;
 	case class'FragAmmo' :
-		Multiplier = LerpStat(KFPRI, 1.f, 2.2f);
+		Multiplier = LerpStat(KFPRI, 1.f, 2.0f);
 		break;
 	}
 
@@ -167,7 +167,7 @@ static function float GetCostScaling(KFPlayerReplicationInfo KFPRI, class<Pickup
 	case class'W_Shotgun_Pickup' :
 	case class'W_NailGun_Pickup' :
 	case class'W_SPShotgun_Pickup' :
-		Multiplier *= LerpStat(KFPRI, 0.9f, 0.3f);
+		Multiplier *= LerpStat(KFPRI, 0.9f, 0.4f);
 		break;
 	}
 
@@ -199,5 +199,5 @@ defaultproperties
 	PerkIndex=1
 	CustomLevelInfo=""
 	Requirements(0)="Deal %x damage with shotguns."
-	SRLevelEffects(6)="60% more damage with shotguns|90% better shotgun penetration|30% extra shotgun ammo|50% more damage with grenades|120% increase in grenade capacity|60% increased carry weight|150% faster welding/unwelding|70% discount on shotguns|Spawn with a Shotgun"
+	SRLevelEffects(6)="60% more damage with shotguns|90% better shotgun penetration|30% extra shotgun ammo|50% more damage with grenades|100% increase in grenade capacity|60% increased carry weight|150% faster welding/unwelding|60% discount on shotguns|Spawn with a Shotgun"
 }

--- a/KFTurbo/Classes/V_SupportSpec.uc
+++ b/KFTurbo/Classes/V_SupportSpec.uc
@@ -167,7 +167,7 @@ static function float GetCostScaling(KFPlayerReplicationInfo KFPRI, class<Pickup
 	case class'W_Shotgun_Pickup' :
 	case class'W_NailGun_Pickup' :
 	case class'W_SPShotgun_Pickup' :
-		Multiplier *= LerpStat(KFPRI, 0.9f, 0.4f);
+		Multiplier *= LerpStat(KFPRI, 0.9f, 0.3f);
 		break;
 	}
 
@@ -199,5 +199,5 @@ defaultproperties
 	PerkIndex=1
 	CustomLevelInfo=""
 	Requirements(0)="Deal %x damage with shotguns."
-	SRLevelEffects(6)="60% more damage with shotguns|90% better shotgun penetration|30% extra shotgun ammo|50% more damage with grenades|100% increase in grenade capacity|60% increased carry weight|150% faster welding/unwelding|60% discount on shotguns|Spawn with a Shotgun"
+	SRLevelEffects(6)="60% more damage with shotguns|90% better shotgun penetration|30% extra shotgun ammo|50% more damage with grenades|100% increase in grenade capacity|60% increased carry weight|150% faster welding/unwelding|70% discount on shotguns|Spawn with a Shotgun"
 }

--- a/KFTurbo/Classes/W_Chainsaw_Fire.uc
+++ b/KFTurbo/Classes/W_Chainsaw_Fire.uc
@@ -127,5 +127,7 @@ function DoFireEffect()
 
 defaultproperties
 {
+	MeleeDamage=22.500000
 	LastHitRegisterCount=-1
+    weaponRange=110.000000
 }

--- a/KFTurbo/Classes/W_Chainsaw_Fire_Alt.uc
+++ b/KFTurbo/Classes/W_Chainsaw_Fire_Alt.uc
@@ -71,6 +71,7 @@ defaultproperties
     NextHitTimerPop = 0.f
 
     MeleeDamage = 540
+    weaponRange=110.000000
     DamagedelayMin=0.50
     DamagedelayMax=0.50
 

--- a/KFTurbo/Classes/W_Crossbow_Proj.uc
+++ b/KFTurbo/Classes/W_Crossbow_Proj.uc
@@ -4,15 +4,16 @@
 class W_Crossbow_Proj extends CrossbowArrow;
 
 var byte bHasRegisteredHit;
+var() float PenetrationDamageMult;
 
 simulated function ProcessTouch(Actor Other, vector HitLocation)
 {
-	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, DamageTypeHeadShot, Other, HitLocation, Arrow_hitarmor, Arrow_hitflesh, IgnoreImpactPawn, bHasRegisteredHit);
+	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, PenetrationDamageMult, DamageTypeHeadShot, Other, HitLocation, Arrow_hitarmor, Arrow_hitflesh, IgnoreImpactPawn, bHasRegisteredHit);
 
 	Stick(Other, HitLocation);
 }
 
 defaultproperties
 {
-
+     PenetrationDamageMult=0.800000
 }

--- a/KFTurbo/Classes/W_Crossbuzzsaw_Proj.uc
+++ b/KFTurbo/Classes/W_Crossbuzzsaw_Proj.uc
@@ -4,14 +4,24 @@
 class W_Crossbuzzsaw_Proj extends CrossbuzzsawBlade;
 
 var byte bHasRegisteredHit;
+var() float PenetrationDamageMult;
 
 simulated function ProcessTouch(Actor Other, vector HitLocation)
 {
-	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, DamageTypeHeadShot, Other, HitLocation, BladeHitArmor, BladeHitFlesh, IgnoreImpactPawn, bHasRegisteredHit);
+	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, PenetrationDamageMult, DamageTypeHeadShot, Other, HitLocation, BladeHitArmor, BladeHitFlesh, IgnoreImpactPawn, bHasRegisteredHit);
+}    
+
+simulated function HitWall( vector HitNormal, actor Wall )
+{
+    Super.HitWall(HitNormal, Wall);
+
+    IgnoreImpactPawn = None;
 }
 
 defaultproperties
 {
      HeadShotDamageMult=2.000000
+     PenetrationDamageMult=1.000000
+     StraightFlightTime=0.900000
      Damage=275.000000
 }

--- a/KFTurbo/Classes/W_FNFAL_Pickup.uc
+++ b/KFTurbo/Classes/W_FNFAL_Pickup.uc
@@ -17,7 +17,8 @@ function Destroyed()
 
 defaultproperties
 {
-     cost=2500
+	 Weight=8.000000
+     Cost=4000
      VariantClasses(0)=Class'KFTurbo.W_FNFAL_Pickup'
      VariantClasses(1)=Class'KFTurbo.W_V_FNFAL_Turbo_Pickup'
      InventoryType=Class'KFTurbo.W_FNFAL_Weap'

--- a/KFTurbo/Classes/W_FNFAL_Pickup.uc
+++ b/KFTurbo/Classes/W_FNFAL_Pickup.uc
@@ -17,7 +17,7 @@ function Destroyed()
 
 defaultproperties
 {
-	 Weight=8.000000
+	 Weight=6.000000
      Cost=2500
      VariantClasses(0)=Class'KFTurbo.W_FNFAL_Pickup'
      VariantClasses(1)=Class'KFTurbo.W_V_FNFAL_Turbo_Pickup'

--- a/KFTurbo/Classes/W_FNFAL_Pickup.uc
+++ b/KFTurbo/Classes/W_FNFAL_Pickup.uc
@@ -18,7 +18,7 @@ function Destroyed()
 defaultproperties
 {
 	 Weight=8.000000
-     Cost=4000
+     Cost=2500
      VariantClasses(0)=Class'KFTurbo.W_FNFAL_Pickup'
      VariantClasses(1)=Class'KFTurbo.W_V_FNFAL_Turbo_Pickup'
      InventoryType=Class'KFTurbo.W_FNFAL_Weap'

--- a/KFTurbo/Classes/W_FNFAL_Weap.uc
+++ b/KFTurbo/Classes/W_FNFAL_Weap.uc
@@ -11,6 +11,7 @@ function AddReloadedAmmo()
 
 defaultproperties
 {
+     Weight=8.000000
      MagCapacity=12
      ReloadRate=3.200000
      ReloadAnimRate=1.125000

--- a/KFTurbo/Classes/W_FNFAL_Weap.uc
+++ b/KFTurbo/Classes/W_FNFAL_Weap.uc
@@ -11,7 +11,7 @@ function AddReloadedAmmo()
 
 defaultproperties
 {
-     Weight=8.000000
+     Weight=6.000000
      MagCapacity=12
      ReloadRate=3.200000
      ReloadAnimRate=1.125000

--- a/KFTurbo/Classes/W_Flamethrower_Ammo.uc
+++ b/KFTurbo/Classes/W_Flamethrower_Ammo.uc
@@ -5,5 +5,7 @@ class W_Flamethrower_Ammo extends FlameAmmo;
 
 defaultproperties
 {
-
+     AmmoPickupAmount=100
+     MaxAmmo=500
+     InitialAmount=500
 }

--- a/KFTurbo/Classes/W_Katana_Pickup.uc
+++ b/KFTurbo/Classes/W_Katana_Pickup.uc
@@ -22,5 +22,4 @@ defaultproperties
      VariantClasses(2)=Class'KFTurbo.W_V_Katana_VM_Pickup'
      VariantClasses(3)=Class'KFTurbo.W_V_Katana_Vet_Pickup'
      InventoryType=Class'KFTurbo.W_Katana_Weap'
-     Cost=1500
 }

--- a/KFTurbo/Classes/W_Katana_Pickup.uc
+++ b/KFTurbo/Classes/W_Katana_Pickup.uc
@@ -22,4 +22,5 @@ defaultproperties
      VariantClasses(2)=Class'KFTurbo.W_V_Katana_VM_Pickup'
      VariantClasses(3)=Class'KFTurbo.W_V_Katana_Vet_Pickup'
      InventoryType=Class'KFTurbo.W_Katana_Weap'
+     Cost=1500
 }

--- a/KFTurbo/Classes/W_M79_Pickup.uc
+++ b/KFTurbo/Classes/W_M79_Pickup.uc
@@ -17,7 +17,7 @@ function Destroyed()
 
 defaultproperties
 {
-     Cost=750
+     Cost=600
      InventoryType=Class'KFTurbo.W_M79_Weap'
      VariantClasses(0)=Class'KFTurbo.W_M79_Pickup'
      VariantClasses(1)=Class'KFTurbo.W_V_M79_Gold_Pickup'

--- a/KFTurbo/Classes/W_M99_Proj.uc
+++ b/KFTurbo/Classes/W_M99_Proj.uc
@@ -5,6 +5,7 @@ class W_M99_Proj extends M99Bullet;
 
 var bool bRefreshedLifeSpan;
 var byte bHasRegisteredHit;
+var() float PenetrationDamageMult;
 
 simulated function HitWall( vector HitNormal, actor Wall)
 {
@@ -35,11 +36,12 @@ simulated function HitWall( vector HitNormal, actor Wall)
 
 simulated function ProcessTouch(Actor Other, vector HitLocation)
 {
-	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, DamageTypeHeadShot, Other, HitLocation, Arrow_hitarmor, Arrow_hitflesh, IgnoreImpactPawn, bHasRegisteredHit);
+	class'WeaponHelper'.static.CrossbowProjectileProcessTouch(Self, HeadShotDamageMult, PenetrationDamageMult, DamageTypeHeadShot, Other, HitLocation, Arrow_hitarmor, Arrow_hitflesh, IgnoreImpactPawn, bHasRegisteredHit);
 }
 
 defaultproperties
 {
      HeadShotDamageMult=2.250000
+     PenetrationDamageMult=0.800000
      Damage=490.000000
 }

--- a/KFTurbo/Classes/W_NailGun_Pickup.uc
+++ b/KFTurbo/Classes/W_NailGun_Pickup.uc
@@ -18,6 +18,6 @@ function Destroyed()
 defaultproperties
 {
      Weight=9.000000
-     cost=2000
+     cost=1000
      InventoryType=Class'KFTurbo.W_NailGun_Weap'
 }

--- a/KFTurbo/Classes/W_NailGun_Pickup.uc
+++ b/KFTurbo/Classes/W_NailGun_Pickup.uc
@@ -17,7 +17,7 @@ function Destroyed()
 
 defaultproperties
 {
-     Weight=11.000000
-     cost=3000
+     Weight=9.000000
+     cost=2000
      InventoryType=Class'KFTurbo.W_NailGun_Weap'
 }

--- a/KFTurbo/Classes/W_NailGun_Proj.uc
+++ b/KFTurbo/Classes/W_NailGun_Proj.uc
@@ -149,6 +149,6 @@ defaultproperties
      DrawScale=3.000000
      PenDamageReduction=0.900000
      
-     Damage=250.000000
+     Damage=260.000000
      MyDamageType=Class'KFTurbo.W_NailGun_DT'
 }

--- a/KFTurbo/Classes/W_NailGun_Weap.uc
+++ b/KFTurbo/Classes/W_NailGun_Weap.uc
@@ -322,7 +322,7 @@ defaultproperties
 	SpotProjectorPullback=1.000000
 	LaserAttachmentClass=Class'KFTurbo.W_NailGun_LaserAttachment1st'
 	MagCapacity=3
-	Weight=11.000000
+    Weight=9.000000
 	FireModeClass(0)=Class'KFTurbo.W_NailGun_Fire'
 	FireModeClass(1)=Class'KFMod.NoFire'
 	InventoryGroup=4

--- a/KFTurbo/Classes/W_SealSqueal_Ammo.uc
+++ b/KFTurbo/Classes/W_SealSqueal_Ammo.uc
@@ -5,5 +5,5 @@ class W_SealSqueal_Ammo extends SealSquealAmmo;
 
 defaultproperties
 {
-
+     MaxAmmo=45
 }

--- a/KFTurbo/Classes/W_SealSqueal_Ammo.uc
+++ b/KFTurbo/Classes/W_SealSqueal_Ammo.uc
@@ -5,5 +5,5 @@ class W_SealSqueal_Ammo extends SealSquealAmmo;
 
 defaultproperties
 {
-     MaxAmmo=45
+     MaxAmmo=39
 }

--- a/KFTurbo/Classes/W_SealSqueal_Proj.uc
+++ b/KFTurbo/Classes/W_SealSqueal_Proj.uc
@@ -387,7 +387,7 @@ simulated function CheckPawnBase(Pawn PawnBase)
 defaultproperties
 {
 	ImpactDamage=0
-	Damage=400.000000
+	Damage=430.000000
 	DamageRadius=350.000000
     bGameRelevant=false
 }

--- a/KFTurbo/Classes/WeaponHelper.uc
+++ b/KFTurbo/Classes/WeaponHelper.uc
@@ -947,7 +947,7 @@ static final function SPGrenadeProjTakeDamage(SPGrenadeProjectile Projectile, in
     }
 }
 
-static final function CrossbowProjectileProcessTouch(Projectile Projectile, float HeadshotDamageMulti, class<DamageType> HeadshotDamageType, Actor Other, vector HitLocation, Sound HitArmor, Sound HitFlesh, out Pawn IgnoreImpactPawn, out byte bHasRegisteredHit)
+static final function CrossbowProjectileProcessTouch(Projectile Projectile, float HeadshotDamageMulti, float PenetrationDamageMulti, class<DamageType> HeadshotDamageType, Actor Other, vector HitLocation, Sound HitArmor, Sound HitFlesh, out Pawn IgnoreImpactPawn, out byte bHasRegisteredHit)
 {
 	local vector X,End,HL,HN;
 	local Vector TempHitLocation, HitNormal;
@@ -989,7 +989,7 @@ static final function CrossbowProjectileProcessTouch(Projectile Projectile, floa
 				HitPawn.ProcessLocationalDamage(Projectile.Damage, Projectile.Instigator, TempHitLocation, Projectile.MomentumTransfer * X, Projectile.MyDamageType, HitPoints);
 			}
 
-			Projectile.Damage /= 1.25;
+			Projectile.Damage *= PenetrationDamageMulti;
 			Projectile.Velocity *= 0.85;
 
 			IgnoreImpactPawn = HitPawn;
@@ -1033,7 +1033,7 @@ static final function CrossbowProjectileProcessTouch(Projectile Projectile, floa
 			class'TurboPlayerEventHandler'.static.BroadcastPlayerFireHit(Projectile.Owner.Instigator.Controller, Weapon(Projectile.Owner).GetFireMode(0), HitData);
 		}
 
-		Projectile.Damage /= 1.25;
+		Projectile.Damage *= PenetrationDamageMulti;
 		Projectile.Velocity *= 0.85;
 
 		return;


### PR DESCRIPTION
- Berserker:
   - Chainsaw
        - Weapon range 70 -> 110
   - Buzzsaw
       - remove penetration damage loss 
       - straight flight time increased from 0.65s to 0.9s
       - can hit same target after bouncing (bug)
 
- Firebug:
    - Flamethrower
        - ammo increased from 400 to 500 (perked 480 to 600)

- Demo:
    - SealSqueal
        - ammo increased from 30 to 39
        - damage increased from 400 to 430 (this allows 3x SS headshot + 1 point blank frag grenade FP takedowns)
    - M79
        - price decreased from 750 to 600

- Commando:
    - FAL
        - Ammo bonus decreased from 25% to 12.5% (240 to 216 total perked ammo)
    - Grenade	
        - Carried amount increased from 5 to 8
    - Perk
        - All non-commando weapons receive a 10% discount

- Support:
    - VLAD
        - weight reduced from 11 to 9
        - damage increased from 250 to 260, this allows 1-shot headshot on Sirens and Husks Off-perk
        - price reduced from 3000 to 1000 to allow easier off-perk purchase
    - Grenade
        - Carried amount decreased from 11 to 10

- Sharpshooter:
    - Perk	
        - VLAD Bonus removed

- Scrake:
    - 55% vulnerability to VLAD headshots, allowing it to stun off-perk

- Clot:
    - 25% vulnerability to Flamethrower

- Crawler:
    - 25% vulnerability to Flamethrower